### PR TITLE
Fix double-logging issue in CLI commands

### DIFF
--- a/sprig/logger.py
+++ b/sprig/logger.py
@@ -5,18 +5,23 @@ import sys
 
 
 def get_logger(name: str = "sprig") -> logging.Logger:
-    """Get a console logger with configurable level."""
+    """Get a console logger with configurable level.
+
+    Only the root 'sprig' logger gets a handler. Child loggers
+    (e.g., 'sprig.auth', 'sprig.sync') propagate to the root.
+    """
     logger = logging.getLogger(name)
 
-    if logger.handlers:
-        return logger
+    # Only add a handler to the root 'sprig' logger
+    # Child loggers will propagate to it, avoiding duplicate messages
+    if name == "sprig" and not logger.handlers:
+        handler = logging.StreamHandler(sys.stdout)
+        level = getattr(logging, os.getenv("LOG_LEVEL", "INFO").upper(), logging.INFO)
 
-    handler = logging.StreamHandler(sys.stdout)
-    level = getattr(logging, os.getenv("LOG_LEVEL", "INFO").upper(), logging.INFO)
+        logger.setLevel(level)
+        handler.setLevel(level)
+        handler.setFormatter(logging.Formatter("%(message)s"))
 
-    logger.setLevel(level)
-    handler.setLevel(level)
-    handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
 
-    logger.addHandler(handler)
     return logger

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,62 @@
+"""Tests for the logging configuration."""
+
+import logging
+from sprig.logger import get_logger
+
+
+def test_root_logger_has_handler():
+    """Root 'sprig' logger should have exactly one handler."""
+    logger = get_logger()
+    assert len(logger.handlers) == 1
+
+
+def test_child_logger_has_no_handler():
+    """Child loggers should have no handlers and rely on propagation."""
+    # First ensure root logger exists
+    get_logger()
+
+    # Create child loggers
+    auth_logger = get_logger("sprig.auth")
+    sync_logger = get_logger("sprig.sync")
+
+    assert len(auth_logger.handlers) == 0
+    assert len(sync_logger.handlers) == 0
+
+
+def test_no_double_logging(caplog):
+    """Messages from child loggers should only appear once.
+
+    This test verifies that child loggers don't create duplicate messages
+    due to having their own handlers plus propagation to parent handlers.
+    """
+    # Clear any existing logs
+    caplog.clear()
+
+    # Set up logging capture
+    with caplog.at_level(logging.INFO):
+        # Get root logger (creates handler)
+        root_logger = get_logger()
+
+        # Get child logger (no handler)
+        child_logger = get_logger("sprig.auth")
+
+        # Verify handler configuration
+        assert len(root_logger.handlers) == 1, "Root logger should have 1 handler"
+        assert len(child_logger.handlers) == 0, "Child logger should have 0 handlers"
+
+        # Log a message
+        test_message = "Test message for double logging"
+        child_logger.info(test_message)
+
+        # Check that message was logged exactly once
+        matching_records = [r for r in caplog.records if test_message in r.message]
+        assert len(matching_records) == 1, f"Expected 1 log record, found {len(matching_records)}"
+
+
+def test_child_logger_propagates_to_root():
+    """Child loggers should propagate to root."""
+    get_logger()  # Create root
+    child_logger = get_logger("sprig.auth")
+
+    assert child_logger.propagate is True
+    assert child_logger.parent.name == "sprig"


### PR DESCRIPTION
Resolves #23

The CLI was outputting duplicate log messages because both parent and child loggers had their own StreamHandlers. When a child logger (e.g., "sprig.auth") logged a message, it would output to:
1. Its own StreamHandler
2. The parent "sprig" logger's StreamHandler (via propagation)

Changes:
- Modified get_logger() to only add a StreamHandler to the root "sprig" logger
- Child loggers now rely on propagation to the root logger
- Added comprehensive tests for logging behavior

All log messages now appear exactly once in the terminal output.