### PR TITLE
Resolve GitHub issue #29

### DIFF
--- a/sprig/export.py
+++ b/sprig/export.py
@@ -16,7 +16,7 @@ def export_transactions_to_csv(database_path, output_path=None):
         # Create exports directory if it doesn't exist
         exports_dir = Path("exports")
         exports_dir.mkdir(exist_ok=True)
-        output_path = exports_dir / f"transactions-{datetime.now().strftime('%Y-%m-%d')}.csv"
+        output_path = exports_dir / f"transactions-{datetime.now().strftime('%Y-%m-%d_%H%M%S')}.csv"
 
     logger.info(f"Starting export to {output_path}")
 


### PR DESCRIPTION
Updated export filename format from 'transactions-YYYY-MM-DD.csv' to 'transactions-YYYY-MM-DD_HHMMSS.csv' to ensure each export creates a unique file. This prevents multiple exports on the same day from overwriting previous exports.

Fixes #29