### PR TITLE
This change limits CSV exports to 9 essential fields instead of all Teller API data

### DIFF
--- a/sprig/export.py
+++ b/sprig/export.py
@@ -27,11 +27,10 @@ def export_transactions_to_csv(database_path, output_path=None):
         logger.warning("No transactions found to export.")
         return
 
-    # Get column names from database schema
+    # Column names matching the 9-field export query
     column_names = [
-        'id', 'account_id', 'amount', 'description', 'date',
-        'type', 'status', 'details', 'running_balance', 'links',
-        'inferred_category', 'created_at'
+        'id', 'date', 'description', 'amount', 'inferred_category',
+        'counterparty', 'account_name', 'account_subtype', 'account_last_four'
     ]
 
     logger.debug(f"Exporting {len(transactions)} transaction(s) with {len(column_names)} columns")

--- a/sprig/models/__init__.py
+++ b/sprig/models/__init__.py
@@ -1,17 +1,17 @@
 """Sprig data models for API responses and configuration."""
 
 from .teller import TellerAccount, TellerTransaction
-from .claude import ClaudeResponse, ClaudeContentBlock, TransactionCategory, TransactionForCategorization
+from .claude import ClaudeResponse, ClaudeContentBlock, TransactionCategory, TransactionView
 from .runtime_config import RuntimeConfig
 from .category_config import CategoryConfig, Category
 
 __all__ = [
     "TellerAccount",
-    "TellerTransaction", 
+    "TellerTransaction",
     "ClaudeResponse",
     "ClaudeContentBlock",
     "TransactionCategory",
-    "TransactionForCategorization",
+    "TransactionView",
     "RuntimeConfig",
     "CategoryConfig",
     "Category",

--- a/sprig/models/claude.py
+++ b/sprig/models/claude.py
@@ -11,15 +11,21 @@ class TransactionCategory(BaseModel):
     category: str
 
 
-class TransactionForCategorization(BaseModel):
-    """Essential transaction data for categorization and export."""
+class TransactionView(BaseModel):
+    """Essential transaction data for categorization and CSV export.
+
+    This model contains the 9 fields exported to CSV and sent to Claude for categorization.
+    Fields are ordered to match the desired CSV column order.
+    """
     id: str
+    date: str  # Keep as string for simpler JSON
     description: str
     amount: float
-    date: str  # Keep as string for simpler JSON
+    inferred_category: Optional[str] = None
     counterparty: Optional[str] = None
     account_name: Optional[str] = None
     account_subtype: Optional[str] = None
+    account_last_four: Optional[str] = None
 
 
 class ClaudeContentBlock(BaseModel):

--- a/sprig/sync.py
+++ b/sprig/sync.py
@@ -154,8 +154,8 @@ def categorize_uncategorized_transactions(runtime_config: RuntimeConfig, db: Spr
     for row in uncategorized:
         txn_id = row[0]
         txn_data = {
-            "id": txn_id, "description": row[1], "amount": row[2], 
-            "date": row[3], "type": row[4], "account_id": row[5], 
+            "id": txn_id, "description": row[1], "amount": row[2],
+            "date": row[3], "type": row[4], "account_id": row[5],
             "status": "posted"
         }
         transactions.append(TellerTransaction(**txn_data))
@@ -163,7 +163,8 @@ def categorize_uncategorized_transactions(runtime_config: RuntimeConfig, db: Spr
         account_info[txn_id] = {
             "name": row[6],
             "subtype": row[7],
-            "counterparty": row[8]  # counterparty from JSON extraction
+            "counterparty": row[8],  # counterparty from JSON extraction
+            "last_four": row[9]  # account last four digits
         }
     
     if not transactions:

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -10,51 +10,51 @@ from sprig.export import export_transactions_to_csv
 
 
 def test_export_transactions_to_csv_with_data():
-    """Test CSV export with mock transaction data."""
-    # Mock transaction data (SQLite row format)
+    """Test CSV export with mock transaction data (9-field format)."""
+    # Mock transaction data (new SQLite row format with JOINed account data)
+    # Format: id, date, description, amount, inferred_category, counterparty, account_name, account_subtype, account_last_four
     mock_transactions = [
-        ('txn_1', 'acc_1', -25.50, 'Coffee Shop', '2024-01-01', 'debit', 'posted', None, 100.50, None, 'dining', '2024-01-01 10:00:00'),
-        ('txn_2', 'acc_1', -45.00, 'Gas Station', '2024-01-02', 'debit', 'posted', None, 55.50, None, 'fuel', '2024-01-02 15:30:00'),
+        ('txn_1', '2024-01-01', 'Coffee Shop', -25.50, 'dining', 'Coffee Shop Inc', 'Checking', 'checking', '1234'),
+        ('txn_2', '2024-01-02', 'Gas Station', -45.00, 'transport', 'Shell Gas', 'Checking', 'checking', '1234'),
     ]
-    
+
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_db_path = Path(temp_dir) / "test.db"
         output_path = Path(temp_dir) / "test_export.csv"
-        
+
         # Mock the database
         with patch('sprig.export.SprigDatabase') as mock_db_class:
             mock_db = Mock()
             mock_db.get_transactions_for_export.return_value = mock_transactions
             mock_db_class.return_value = mock_db
-            
+
             # Test export
             export_transactions_to_csv(temp_db_path, output_path)
-            
+
             # Verify database was called correctly
             mock_db_class.assert_called_once_with(temp_db_path)
             mock_db.get_transactions_for_export.assert_called_once()
-            
+
             # Verify CSV file was created and has correct content
             assert output_path.exists()
-            
+
             with open(output_path, 'r', encoding='utf-8') as csvfile:
                 reader = csv.reader(csvfile)
                 rows = list(reader)
-                
-                # Check header
+
+                # Check header (new 9-field format)
                 expected_header = [
-                    'id', 'account_id', 'amount', 'description', 'date', 
-                    'type', 'status', 'details', 'running_balance', 'links', 
-                    'inferred_category', 'created_at'
+                    'id', 'date', 'description', 'amount', 'inferred_category',
+                    'counterparty', 'account_name', 'account_subtype', 'account_last_four'
                 ]
                 assert rows[0] == expected_header
-                
+
                 # Check data rows
                 assert len(rows) == 3  # header + 2 data rows
                 assert rows[1][0] == 'txn_1'  # id
-                assert rows[1][3] == 'Coffee Shop'  # description
+                assert rows[1][2] == 'Coffee Shop'  # description
                 assert rows[2][0] == 'txn_2'  # id
-                assert rows[2][3] == 'Gas Station'  # description
+                assert rows[2][2] == 'Gas Station'  # description
 
 
 def test_export_transactions_to_csv_no_data():
@@ -78,8 +78,9 @@ def test_export_transactions_to_csv_no_data():
 
 def test_export_transactions_to_csv_default_filename():
     """Test CSV export with default filename."""
+    # Mock transaction data (new 9-field format)
     mock_transactions = [
-        ('txn_1', 'acc_1', -25.50, 'Coffee Shop', '2024-01-01', 'debit', 'posted', None, 100.50, None, 'dining', '2024-01-01 10:00:00'),
+        ('txn_1', '2024-01-01', 'Coffee Shop', -25.50, 'dining', 'Coffee Shop Inc', 'Checking', 'checking', '1234'),
     ]
     
     with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
This change limits CSV exports to 9 essential fields instead of all Teller API data:
- id, date, description, amount, inferred_category
- counterparty, account_name, account_subtype, account_last_four

Changes:
- Renamed TransactionForCategorization to TransactionView for reusability
- Updated database query to JOIN accounts table and extract counterparty
- Modified export.py to use new 9-field format
- Updated categorizer.py to populate account_last_four field
- Refreshed all export tests to validate new format

This provides users with cleaner CSV exports containing only the fields they care about while removing Teller API implementation details like links, running_balance, and created_at.