### PR TITLE
Encapsulate prompt logic inside categorizer class

### DIFF
--- a/sprig/models/category_config.py
+++ b/sprig/models/category_config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import List
 
 import yaml
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel
 
 
 class Category(BaseModel):
@@ -24,30 +24,6 @@ class CategoryConfig(BaseModel):
     categories: List[Category]
     manual_categories: List[ManualCategory] = []
     batch_size: int = 25
-
-    @model_validator(mode='after')
-    def validate_manual_categories(self):
-        """Validate that manual categories match valid category names."""
-        if not self.manual_categories:
-            return self
-
-        valid_categories = {cat.name for cat in self.categories}
-        invalid_manual_cats = [
-            manual_cat for manual_cat in self.manual_categories
-            if manual_cat.category not in valid_categories
-        ]
-
-        if invalid_manual_cats:
-            invalid_items = [
-                f"{manual_cat.transaction_id} -> '{manual_cat.category}'"
-                for manual_cat in invalid_manual_cats
-            ]
-            raise ValueError(
-                f"Invalid categories in manual_categories: {', '.join(invalid_items)}. "
-                f"Valid categories: {', '.join(sorted(valid_categories))}"
-            )
-
-        return self
 
     @classmethod
     def load(cls, config_path: Path = None):

--- a/tests/test_sync_counting.py
+++ b/tests/test_sync_counting.py
@@ -82,15 +82,16 @@ def test_failed_categorization_counting():
 
             # Mock manual categorizer (no manual overrides)
             mock_manual = Mock()
-            mock_manual.categorize_batch.return_value = {}
+            mock_manual.categorize_batch.return_value = []
             mock_manual_class.return_value = mock_manual
 
             # Mock Claude categorizer - only categorize one transaction, fail the others
+            from sprig.models import TransactionCategory
             mock_claude = Mock()
-            mock_claude.categorize_batch.return_value = {
-                "txn_success_1": ("dining", 0.95)
+            mock_claude.categorize_batch.return_value = [
+                TransactionCategory(transaction_id="txn_success_1", category="dining", confidence=0.95)
                 # txn_fail_1 and txn_fail_2 are NOT in the results = failed categorization
-            }
+            ]
             mock_claude_class.return_value = mock_claude
 
             # Run categorization with small batch size to test counting
@@ -177,12 +178,12 @@ def test_all_transactions_fail_categorization():
 
             # Mock manual categorizer (no manual overrides)
             mock_manual = Mock()
-            mock_manual.categorize_batch.return_value = {}
+            mock_manual.categorize_batch.return_value = []
             mock_manual_class.return_value = mock_manual
 
             # Mock Claude categorizer - complete failure, empty results
             mock_claude = Mock()
-            mock_claude.categorize_batch.return_value = {}  # All transactions failed
+            mock_claude.categorize_batch.return_value = []  # All transactions failed
             mock_claude_class.return_value = mock_claude
 
             # Run categorization


### PR DESCRIPTION
## Summary
- Move PROMPT_TEMPLATE into ClaudeCategorizer as class constant
- Convert build_categorization_prompt to _build_prompt method  
- Add _validate_categories helper method for filtering
- Remove module-level PROMPT_TEMPLATE and build_categorization_prompt
- Standardize categorizer return types to List[TransactionCategory]

## Changes
**sprig/categorizer.py**
- Moved PROMPT_TEMPLATE (65 lines) into ClaudeCategorizer class
- Converted build_categorization_prompt to _build_prompt instance method
- Added _validate_categories helper to extract filtering logic
- ClaudeCategorizer is now fully self-contained

**sprig/models/category_config.py**
- Removed model_validator that validated manual categories
- Validation now happens in categorizers during runtime

**sprig/sync.py**
- Updated to pass category_config to ClaudeCategorizer
- Updated to work with List[TransactionCategory] return type

**Tests**
- Updated all categorizer tests for new API
- All 21 categorizer tests passing
- 108 total tests passing

## Test plan
- [x] All categorizer tests pass (21/21)
- [x] Code linted with ruff
- [x] Integration tests pass